### PR TITLE
Fixed bug for nextKeyNum() function. The generated key for non-insert

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -386,7 +386,7 @@ public class CoreWorkload extends Workload {
     recordcount =
         Long.parseLong(p.getProperty(Client.RECORD_COUNT_PROPERTY, Client.DEFAULT_RECORD_COUNT));
     if (recordcount == 0)
-      recordcount = Integer.MAX_VALUE;
+      recordcount = Long.MAX_VALUE;
     String requestdistrib =
         p.getProperty(REQUEST_DISTRIBUTION_PROPERTY, REQUEST_DISTRIBUTION_PROPERTY_DEFAULT);
     int maxscanlength =
@@ -668,7 +668,7 @@ public class CoreWorkload extends Workload {
       } while (keynum < 0);
     } else {
       do {
-        keynum = keychooser.nextValue().intValue();
+        keynum = keychooser.nextValue().longValue();
       } while (keynum > transactioninsertkeysequence.lastValue());
     }
     return keynum;


### PR DESCRIPTION
operations was returning an integer instead of long, resulting in
generation of non-existent keys for lookups. 

Additionally, default recordcount is set as Long.MAX_VALUE instead of
Integer.MAX_VALUE,
